### PR TITLE
Fix compilation for gcc 7.2 release build

### DIFF
--- a/inc/graph.h
+++ b/inc/graph.h
@@ -35,10 +35,13 @@ namespace INCLUDE_GARDENER
 
 /// @brief Edge Properties.
 /// @author feddischson
-typedef struct
+struct Edge
 {
-   int line; ///< The line number where the include statement is defined.
-} Edge;
+   Edge() = default;
+   Edge(int l) : line(l) {}
+
+   int line = -1; ///< The line number where the include statement is defined.
+};
 
 
 /// @brief Graph definition.


### PR DESCRIPTION
This fixes a "may be used uninitialized in this function [-Werror=maybe-uninitialized]" error I get when compiling a release build with gcc 7.2.

Here is the full compilation commands for reference:

>➜  build git:(master) ✗ cmake .. -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is GNU 7.2.0
-- The CXX compiler identification is GNU 7.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Boost version: 1.65.1
-- Found the following Boost libraries:
--   log
--   system
--   filesystem
--   program_options
--   date_time
--   log_setup
--   thread
--   regex
--   chrono
--   atomic
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jonas/Coding/include_gardener/build/googletest-download
Scanning dependencies of target googletest
[ 11%] Creating directories for 'googletest'
[ 22%] Performing download step (git clone) for 'googletest'
Cloning into 'googletest-src'...
Already on 'master'
Your branch is up-to-date with 'origin/master'.
[ 33%] No patch step for 'googletest'
[ 44%] Performing update step for 'googletest'
Current branch master is up to date.
[ 55%] No configure step for 'googletest'
[ 66%] No build step for 'googletest'
[ 77%] No install step for 'googletest'
[ 88%] No test step for 'googletest'
[100%] Completed 'googletest'
[100%] Built target googletest
-- Found PythonInterp: /usr/bin/python (found version "3.6.2") 
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jonas/Coding/include_gardener/build
➜  build git:(master) ✗ make
Scanning dependencies of target gtest
[  4%] Building CXX object googletest-build/googlemock/gtest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
[  8%] Linking CXX static library libgtest.a
[  8%] Built target gtest
Scanning dependencies of target gtest_main
[ 12%] Building CXX object googletest-build/googlemock/gtest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
[ 16%] Linking CXX static library libgtest_main.a
[ 16%] Built target gtest_main
Scanning dependencies of target gmock_main
[ 20%] Building CXX object googletest-build/googlemock/CMakeFiles/gmock_main.dir/__/googletest/src/gtest-all.cc.o
[ 25%] Building CXX object googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock-all.cc.o
[ 29%] Building CXX object googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o
[ 33%] Linking CXX static library libgmock_main.a
[ 33%] Built target gmock_main
Scanning dependencies of target gmock
[ 37%] Building CXX object googletest-build/googlemock/CMakeFiles/gmock.dir/__/googletest/src/gtest-all.cc.o
[ 41%] Building CXX object googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
[ 45%] Linking CXX static library libgmock.a
[ 45%] Built target gmock
Scanning dependencies of target unit_test
[ 50%] Building CXX object CMakeFiles/unit_test.dir/src/config.cpp.o
[ 54%] Building CXX object CMakeFiles/unit_test.dir/src/detector.cpp.o
[ 58%] Building CXX object CMakeFiles/unit_test.dir/test/unit_test/main.cpp.o
[ 62%] Building CXX object CMakeFiles/unit_test.dir/test/unit_test/test_config.cpp.o
[ 66%] Building CXX object CMakeFiles/unit_test.dir/test/unit_test/test_detector.cpp.o
[ 70%] Linking CXX executable unit_test
[ 70%] Built target unit_test
Scanning dependencies of target include_gardener
[ 75%] Building CXX object CMakeFiles/include_gardener.dir/src/main.cpp.o
[ 79%] Building CXX object CMakeFiles/include_gardener.dir/src/include_entry.cpp.o
[ 83%] Building CXX object CMakeFiles/include_gardener.dir/src/parser.cpp.o
In file included from /home/jonas/Coding/include_gardener/inc/parser.h:38:0,
                 from /home/jonas/Coding/include_gardener/src/parser.cpp:21:
/home/jonas/Coding/include_gardener/inc/graph.h: In member function ‘void INCLUDE_GARDENER::Parser::walk_file(const string&, const string&)’:
/home/jonas/Coding/include_gardener/inc/graph.h:41:3: error: ‘p.INCLUDE_GARDENER::Edge::line’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 } Edge;
   ^~~~
In file included from /usr/include/boost/graph/adjacency_list.hpp:223:0,
                 from /home/jonas/Coding/include_gardener/inc/graph.h:27,
                 from /home/jonas/Coding/include_gardener/inc/parser.h:38,
                 from /home/jonas/Coding/include_gardener/src/parser.cpp:21:
/usr/include/boost/graph/detail/adjacency_list.hpp:2236:43: note: ‘p.INCLUDE_GARDENER::Edge::line’ was declared here
       typename Config::edge_property_type p;
                                           ^
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/include_gardener.dir/build.make:111: CMakeFiles/include_gardener.dir/src/parser.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:108: CMakeFiles/include_gardener.dir/all] Error 2
make: *** [Makefile:141: all] Error 2