### PR TITLE
Updated README.md with Python test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Test Dependencies:
  - PyUnit
  - PyGraphviz
  - PyGraphml
+ - XMLRunner
 
 ```
 mkdir build

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Test Dependencies:
  - PyGraphml
  - XMLRunner
 
+Note: `pip` requires GraphViz development files to install PyGraphViz and PyGraphML.
+To install these libraries using `apt-get`, run `sudo apt-get libgraphviz-dev`
+
 ```
 mkdir build
 cd build


### PR DESCRIPTION
While setting up the `cmd_line` test, I found that there were a couple hitches downloading the required Python packages:
- I needed a Python package named `xmlrunner`,
- I needed to get the development libraries before installing `pygraphviz` and `pygraphml` with `pip`.

It'd be a good idea to put these in the README.