### PR TITLE
CMake: Add boost-regex as dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set ( GARDENER_VERSION
 
 set ( CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(Boost REQUIRED COMPONENTS log system filesystem program_options )
+find_package(Boost REQUIRED COMPONENTS log system filesystem program_options regex )
 if(Boost_FOUND)
   include_directories( SYSTEM ${Boost_INCLUDE_DIRS})
 else()


### PR DESCRIPTION
`boost-regex` must be specified in CMake components. Otherwise, if it is not installed, we got an error at the linking stage:

```
[  3%] Linking CXX executable include_gardener
/usr/bin/ld: CMakeFiles/include_gardener.dir/src/statement_detector.cpp.o: undefined reference to symbol '_ZN5boost16re_detail_10670012perl_matcherIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaINS_9sub_matchISC_EEENS_12regex_traitsIcNS_16cpp_regex_traitsIcEEEEE4findEv'
/usr/bin/ld: //usr/lib/x86_64-linux-gnu/libboost_regex.so.1.67.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/include_gardener.dir/build.make:207: include_gardener] Error 1
make[1]: *** [CMakeFiles/Makefile2:105: CMakeFiles/include_gardener.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```