### PR TITLE
Fixed branch name for google test from master to main

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main 
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Hi 
I fixed the branch name for google test from "master" to "main". Earlier the build was broken, because it could not fetch google test. This issue was originally reported here: https://github.com/feddischson/include_gardener/issues/30